### PR TITLE
Sort code files in the tree

### DIFF
--- a/src/clooj/project.clj
+++ b/src/clooj/project.clj
@@ -103,8 +103,8 @@
 
 (defn get-code-files [dir suffix]
   (let [dir (File. dir)]
-    (filter #(.endsWith (.getName %) suffix)
-            (file-seq dir))))
+    (sort (filter #(.endsWith (.getName %) suffix)
+                  (file-seq dir)))))
 
 (defn path-to-namespace [src-dir file-path]
   (let [drop-suffix #(clojure.contrib.string/butlast 4 %)]


### PR DESCRIPTION
It's much easier to find a particular file when they are displayed in a sorted order in the tree. Some filesystems and OSes might list files in a sorted order by default but ext4 on Linux at least does not.
