### PR TITLE
Save the parent of the last project directory we opened.

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -353,6 +353,7 @@
 (defn open-project [app]
   (when-let [dir (choose-directory (app :f) "Choose a project directory")]
     (let [project-dir (if (= (.getName dir) "src") (.getParentFile dir) dir)]
+      (write-value-to-prefs clooj-prefs "last-open-dir" (.getAbsolutePath (.getParentFile project-dir)))
       (add-project app (.getAbsolutePath project-dir))
       (update-project-tree (:docs-tree app))
       (when-let [clj-file (or (-> (File. project-dir "src")

--- a/src/clooj/utils.clj
+++ b/src/clooj/utils.clj
@@ -377,9 +377,11 @@
         (let [dir (choose-file parent title "" true)]
           (dirs-on false)
           dir))
-    (let [fc (JFileChooser.)]
+    (let [fc (JFileChooser.)
+          last-open-dir (read-value-from-prefs clooj-prefs "last-open-dir")]
       (doto fc (.setFileSelectionMode JFileChooser/DIRECTORIES_ONLY)
-               (.setDialogTitle title))
+               (.setDialogTitle title)
+               (.setCurrentDirectory (if last-open-dir (File. last-open-dir) nil)))
        (if (= JFileChooser/APPROVE_OPTION (.showOpenDialog fc parent))
          (.getSelectedFile fc)))))
 


### PR DESCRIPTION
Hey Arthur,

Small patch to save the parent directory of the last project directory we opened so that on the next Project->Open it will remember where you were last time.

I haven't changed the (is-mac) path (I don't have a mac to test on) so it won't work on a mac.

Steve
