### PR TITLE
Add link to new wiki page for building clooj

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,8 @@ clooj is a work in progress. Please post any suggestions or criticisms to the [c
 
 All feedback is much appreciated. Code contributions in the form of github pull requests are also very welcome!
 
+If you want to start building and working on clooj then please read the [building clooj from source wiki
+page](https://github.com/arthuredelstein/clooj/wiki/Building-clooj).
+
 -- Arthur Edelstein
 


### PR DESCRIPTION
I added a wiki page to the clooj project so it's easy for new developers to get up and running building clooj from source. I added a link to this page in README.md.
