### PR TITLE
Make standard repl commands available from clooj repl

### DIFF
--- a/src/clooj/repl.clj
+++ b/src/clooj/repl.clj
@@ -298,7 +298,12 @@
 
 (defn apply-namespace-to-repl [app]
   (when-let [current-ns (get-file-ns app)]
-    (send-to-repl app (str "(ns " current-ns ")"))
+    (let [ns-str (str "(ns " current-ns
+                      "(:use "
+                      "[clojure.repl :only (source apropos dir pst doc find-doc)] "
+                      "[clojure.java.javadoc :only (javadoc)] "
+                      "[clojure.pprint :only (pp pprint)]))")]
+      (send-to-repl app ns-str))
     (swap! repls assoc-in
            [(-> app :repl deref :project-path) :ns]
            current-ns)))


### PR DESCRIPTION
Hi Arthur,

I've updated the (apply-namespace-to-repl) function to include the various useful repl functions that aren't in clojure.core anymore - things like doc and source.  I've taken the list of functions from the source of clojure.core/repl.

This is both my first github pull request _and_ my first attempt at hacking Clojure, so it's quite possible I've screwed something up in an entertaining way.  Please be gentle...

Thanks, Alan
