### PR TITLE
Text antialiasing in editor and REPL

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -98,6 +98,7 @@
     (.setAnimateBracketMatching false)
     (.setBracketMatchingEnabled false)
     (.setAutoIndentEnabled false)
+    (.setAntiAliasingEnabled true)
     ))
 
 (def get-clooj-version


### PR DESCRIPTION
After clooj has been migrated to RSyntaxTextArea the text in editor is no longer anti-aliased when running on Ubuntu (or any other *nix, I believe). This change forces anti-aliasing on the text area component.
