### PR TITLE
Addition of "Choose Theme" menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The source code editor offers a few simple things to make writing clojure code e
  *  Press ctrl-ENTER to send either the nearest root form or the selected text to the REPL.
  *  Double-click a paren to highlight a form
  *  Source files are continuously saved in the background to prevent accidental loss of your work in the event of a crash.
- *  Syntax highlighting (using the [RSyntaxTextArea](http://fifesoft.com/rsyntaxtextarea/) library)
+ *  Customizable syntax highlighting (using the [RSyntaxTextArea](http://fifesoft.com/rsyntaxtextarea/) library)
 
 ### clojure projects
 Each clojure project corresponds to a project directory somewhere in the file system, containing a src directory. Inside the src directory is the source code hierarchy, composed of directories and .clj files. Note this directory structure is completely compatible with the lein and cake clojure build programs and you are encouraged to use one of these from the command line in conjunction with the clooj editor. Clicking different source files in the projects tree will automatically change the source file currently being edited, as well as switch the REPL to the appropriate namespace.

--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -60,7 +60,7 @@
                             remove-text-change-listeners get-text-str 
                             scroll-to-line get-directories)]
         [clooj.indent :only (setup-autoindent fix-indent-selected-lines)]
-        [clooj.style :only (get-monospaced-fonts show-font-window)]
+        [clooj.style :only (get-monospaced-fonts show-font-window show-theme-window load-theme)]
         [clooj.navigate :only (attach-navigation-keys)])
   (:require [clojure.main :only (repl repl-prompt)]
             [clojure.set])
@@ -92,7 +92,7 @@
                                      token-type)))]
       (.. rsta getDocument (setTokenMakerFactory tmf))
     rsta))
-  
+
 (defn make-text-area [wrap]
   (doto (RSyntaxTextArea.)
     (.setAnimateBracketMatching false)
@@ -737,7 +737,8 @@
       ["Increase font size" nil "cmd1 PLUS" #(grow-font app)]
       ["Decrease font size" nil "cmd1 MINUS" #(shrink-font app)]
       ["Choose font..." nil nil #(apply show-font-window
-                                        app set-font @current-font)])))
+                                        app set-font @current-font)]
+      ["Choose theme..." nil nil #(show-theme-window app)])))
       
     
 (defn add-visibility-shortcut [app]
@@ -777,7 +778,8 @@
     (let [tree (app :docs-tree)]
       (load-expanded-paths tree)
       (load-tree-selection tree))
-    (load-font app)))
+    (load-font app)
+    (load-theme app)))
 
 (defn -show []
   (reset! embedded true)


### PR DESCRIPTION
This enables the user to select a syntax highlighting XML file and saves it to their preferences so it will be applied after a re-start.  It works fine when no theme is selected as well.

Example themes can be found at:

http://svn.fifesoft.com/viewvc-1.0.5/bin/cgi/viewvc.cgi/RSyntaxTextArea/trunk/themes/?root=RSyntaxTextArea
