### PR TITLE
Fixed updating caret position

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -529,9 +529,10 @@
       (do (.setText text-area no-project-txt)
           (.setText doc-label (str "Source Editor (No file selected)"))
           (.setEditable text-area false)))
-    (update-caret-position text-area)
     (indent/setup-autoindent text-area)
     (reset! (app :file) file)
+    (load-caret-position app)
+    (update-caret-position text-area)
     (repl/apply-namespace-to-repl app)
     (reset! changing-file false)))
 


### PR DESCRIPTION
The caret is not updated when switching between files.

It turns out that load-caret-position was not being called and update-caret-position was being called before the app and file were refreshed.

This pull request should ensure that the caret position is being updated properly when switching between files.
