### PR TITLE
Simple catch fix

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -756,7 +756,8 @@
                    (into-array Class [java.awt.Window (. Boolean TYPE)]))
                 invoke
                 util 
-                (object-array [frame true]))))
+                (object-array [frame true])))
+	(catch Exception e "Not Mac OS"))
       (.setVisible frame true)
       (on-window-activation frame #(project/update-project-tree (app :docs-tree))))
     (setup-temp-writer app)


### PR DESCRIPTION
Fix startup crash for Non-Mac OS by adding catch when loading com.apple.eawt.FullScreenUtilities.
