### PR TITLE
The fullscreen capability is only available on MacOSX

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -750,14 +750,15 @@
     (doall (map #(project/add-project app %) (project/load-project-set)))
     (let [frame (app :frame)]
       (utils/persist-window-shape utils/clooj-prefs "main-window" frame) 
-      (try (let [util (. Class forName "com.apple.eawt.FullScreenUtilities")]
-             (. (. util
-                   getMethod 
-                   "setWindowCanFullScreen"
-                   (into-array Class [java.awt.Window (. Boolean TYPE)]))
-                invoke
-                util 
-                (object-array [frame true]))))
+      (when (>= (. (System/getProperty "os.name") indexOf "Mac OS X") 0)
+        (try (let [util (. Class forName "com.apple.eawt.FullScreenUtilities")]
+               (. (. util
+                     getMethod 
+                     "setWindowCanFullScreen"
+                     (into-array Class [java.awt.Window (. Boolean TYPE)]))
+                  invoke
+                  util 
+                  (object-array [frame true])))))
       (.setVisible frame true)
       (on-window-activation frame #(project/update-project-tree (app :docs-tree))))
     (setup-temp-writer app)


### PR DESCRIPTION
If you try to compile on Windows or Linux, the absence of com.apple.eawt.FullScreenUtilities will raise an error, so I followed the instructions of http://saipullabhotla.blogspot.com.br/2012/05/enabling-full-screen-mode-for-java.html to fix it.
