### PR TITLE
When clooj makes a new project, have the project use up-to-date Clojure 1.5.1. 

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -555,9 +555,9 @@
 
 (def project-clj-text (.trim
 "
-(defproject PROJECTNAME \"1.0.0-SNAPSHOT\"
-  :description \"FIXME: write\"
-  :dependencies [[org.clojure/clojure \"1.3.0\"]])
+(defproject PROJECTNAME \"0.1.0-SNAPSHOT\"
+  :description \"FIXME: write description\"
+  :dependencies [[org.clojure/clojure \"1.5.1\"]])
 "))
       
 (defn specify-source [project-dir title default-namespace]


### PR DESCRIPTION
I've imitated the current (as of July 2013) result of running "lein new", minus the part about a license and url.
