### PR TITLE
General clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 classes/
 lib/
 target/
+.lein-repl-history
+.nrepl-port

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .lein-deps-sum
 classes/
 lib/
+target/

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main clooj.core
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-inspector "0.0.12"]
-                 [slamhound "1.2.0"]
-                 [com.cemerick/pomegranate "0.0.11"]
-                 [com.fifesoft/rsyntaxtextarea "2.5.0"]
-                 [org.clojure/tools.nrepl "0.2.3"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [clj-inspector "0.0.16"]
+                 [slamhound "1.5.5"]
+                 [com.cemerick/pomegranate "1.1.0"]
+                 [com.fifesoft/rsyntaxtextarea "3.4.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]])

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main clooj.core
+  :jvm-opts ["--add-exports" "java.desktop/com.apple.eawt=ALL-UNNAMED"]
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-inspector "0.0.16"]
                  [slamhound "1.5.5"]

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,4 @@
                  [slamhound "1.5.5"]
                  [com.cemerick/pomegranate "1.1.0"]
                  [com.fifesoft/rsyntaxtextarea "3.4.0"]
-                 [org.clojure/tools.nrepl "0.2.13"]])
+                 [nrepl/nrepl "1.1.1"]])

--- a/src/clooj/repl/lein.clj
+++ b/src/clooj/repl/lein.clj
@@ -5,7 +5,7 @@
 
 (ns clooj.repl.lein
   (:import (java.io BufferedReader File InputStreamReader))
-  (:require [clojure.tools.nrepl :as nrepl]
+  (:require [nrepl.core :as nrepl]
             [clojure.java.io :as io]
             [clooj.protocols :as protocols]
             [clooj.utils :as utils]))

--- a/src/clooj/repl/lein.clj
+++ b/src/clooj/repl/lein.clj
@@ -65,7 +65,7 @@
   [project-path cmd]
   (->
     (doto (ProcessBuilder. ["lein" cmd])
-      (.redirectErrorStream true)
+      (.redirectErrorStream false)
       (.directory (io/file (or project-path "."))))
     .start))
 

--- a/src/clooj/repl/main.clj
+++ b/src/clooj/repl/main.clj
@@ -15,7 +15,7 @@
            (java.util.concurrent LinkedBlockingQueue))
   (:require [clj-inspector.jars :as jars]
             [clojure.string :as string]
-            [clojure.tools.nrepl :as nrepl]
+            [nrepl.core :as nrepl]
             [clojure.java.io :as io]
             [clooj.brackets :as brackets]
             [clooj.help :as help]

--- a/src/clooj/utils.clj
+++ b/src/clooj/utils.clj
@@ -60,15 +60,6 @@
   (try (Class/forName class-name)
        (catch Throwable _ nil)))
 
-(defn static-method [class-name method-name & arg-types]
-  (let [method
-        (some-> class-name
-                class-for-name
-                (.getMethod method-name
-                            (into-array Class arg-types)))]
-          (fn [& args]
-            (.invoke method nil (object-array args)))))
-
 ;; preferences
   
 ;; define a UUID for clooj preferences
@@ -570,23 +561,9 @@
 
 ;; OS-specific utils
 
-(defn enable-mac-fullscreen
+(defmacro enable-mac-fullscreen
   "Shows the Mac full-screen double arrow, as introduced in
    OS X Lion, if possible."
   [window]
-    (when (is-mac)
-      (let [enable (static-method
-                     "com.apple.eawt.FullScreenUtilities"
-                     "setWindowCanFullScreen"
-                     java.awt.Window
-                     Boolean/TYPE)]
-        (enable window true))))
-
-
-
-
-
-
-
-
-
+  (when (is-mac)
+    `(com.apple.eawt.FullScreenUtilities/setWindowCanFullScreen ~window true)))


### PR DESCRIPTION
Update to handle latest JVMs, update dependencies, switch to `nrepl/nrepl`, and don't redirect the leiningen error stream.

cc @eerohele 