### PR TITLE
Fix or silence all existing clj-kondo errors

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,5 @@
+{:linters {:unused-binding {:level :off}
+           :unused-import {:level :off}
+           :unused-namespace {:level :off}}
+ :lint-as {clooj.utils/when-lets clojure.core/let}
+ :output {:linter-name true}}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clooj "0.5"
   :description "clooj, a small IDE for clojure"
-  :url "https://github.com/arthuredelstein/clooj"
+  :url "https://github.com/clj-commons/clooj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main clooj.core

--- a/src/clooj/brackets.clj
+++ b/src/clooj/brackets.clj
@@ -47,7 +47,7 @@
   (loop [t text pos 0 stack nil errs nil]
     (let [c (first t)        ;this char
           new-stack (process-bracket-stack stack c pos)
-          e (if (mismatched-brackets (ffirst stack) c)
+          e (when (mismatched-brackets (ffirst stack) c)
               (list (first stack) [c pos]))
           new-errs (if e (concat errs e) errs)]
         (if (next t)

--- a/src/clooj/cemerick/pomegranate.clj
+++ b/src/clooj/cemerick/pomegranate.clj
@@ -45,7 +45,7 @@ unless you are extending a type to this protocol."
   [sym & body]
   (when (resolve sym) `(do ~@body)))
 
-(when-resolves sun.misc.Launcher             
+(when-resolves sun.misc.Launcher
   (extend sun.misc.Launcher$ExtClassLoader URLClasspath
     (assoc url-classloader-base
            :can-modify? (constantly false))))

--- a/src/clooj/collaj.clj
+++ b/src/clooj/collaj.clj
@@ -11,7 +11,7 @@
   "URL-encode a string."
   [s]
   (URLEncoder/encode s "UTF-8"))
-  
+
 (defn raw-data
   "Get a clojure data collection of raw search
    results from collaj.net"

--- a/src/clooj/help.clj
+++ b/src/clooj/help.clj
@@ -226,7 +226,7 @@
 
 (defn item-help [item]
   (cond (map? item) (var-help item)
-        (class? item) (class-help item)))    
+        (class? item) (class-help item)))
 
 (defn set-first-component [split-pane comp]
   (let [loc (.getDividerLocation split-pane)]
@@ -286,13 +286,13 @@
                                     (.getSelectedIndex help-list))
                                n))))))
   (show-completion-list app))
-  
+
 (defn get-list-item [app]
   (-> app :completion-list .getSelectedValue))
 
 (defn get-list-artifact [app]
   (when-let [artifact (:artifact (get-list-item app))]
-    (binding [*read-eval* false] 
+    (binding [*read-eval* false]
       (read-string artifact))))
 
 (defn get-list-token [app]
@@ -323,11 +323,11 @@
                            (app :docs-tree-panel))
       (.setText (app :repl-label) "Clojure REPL output"))
     (swap! help-state assoc :visible false :pos nil)))
-  
+
 (defn help-handle-caret-move [app text-comp]
   (utils/awt-event
     (when (@help-state :visible)
-      (let [[start _] (local-token-location (utils/get-text-str text-comp) 
+      (let [[start _] (local-token-location (utils/get-text-str text-comp)
                                             (.getCaretPosition text-comp))]
         (if-not (= start (@help-state :pos))
           (hide-tab-help app)
@@ -351,7 +351,7 @@
     (add-classpath-to-repl app (aether/dependency-files deps)))
   (utils/append-text (app :repl-out-text-area)
                      (str "done.")))
-  
+
 (defn update-token [app text-comp new-token]
   (utils/awt-event
     (let [[start stop] (local-token-location
@@ -388,7 +388,7 @@
       (proxy [DefaultListCellRenderer] []
         (getListCellRendererComponent [list item index isSelected cellHasFocus]
           (doto (proxy-super getListCellRendererComponent list item index isSelected cellHasFocus)
-            (.setText (present-item item)))))) 
+            (.setText (present-item item))))))
     (.addListSelectionListener
       (reify ListSelectionListener
         (valueChanged [_ e]

--- a/src/clooj/help.clj
+++ b/src/clooj/help.clj
@@ -72,7 +72,7 @@
 
 (defn get-var-maps [project-path classpath]
   (make-var-super-map
-      (mapcat vars/analyze-clojure-source
+      (mapcat #(vars/analyze-clojure-source "clj" %)
               (concat
                 (get-sources-from-jars project-path classpath)
                 (get-sources-from-clj-files classpath)))))
@@ -256,7 +256,7 @@
         others (match-items token-pat2 items)
         ;collaj-items (or (try (collaj/raw-data token) (catch Throwable _)))
         ]
-    (concat best others (comment collaj-items))))
+    (concat best others #_collaj-items)))
 
 (defn show-completion-list [{:keys [completion-list
                                     repl-split-pane
@@ -358,8 +358,7 @@
                          (utils/get-text-str text-comp)
                          (.getCaretPosition text-comp))
           len (- stop start)]
-      (when (and (not (empty? new-token)) (-> app :completion-list
-                                              .getModel .getSize pos?))
+      (when (and (seq new-token) (-> app :completion-list .getModel .getSize pos?))
         (.. text-comp getDocument
             (replace start len new-token nil))))))
 
@@ -397,4 +396,4 @@
             (.ensureIndexIsVisible l (.getSelectedIndex l))
             (show-help-text app (.getSelectedValue l))))))
     (utils/on-click 2 #(when-let [text-pane (find-focused-text-pane app)]
-                        (update-token app text-pane)))))
+                        (update-token app text-pane (get-list-token app))))))

--- a/src/clooj/highlighting.clj
+++ b/src/clooj/highlighting.clj
@@ -9,7 +9,7 @@
            (java.awt Color)
            (javax.swing.event CaretListener))
   (:require [clooj.utils :as utils]))
- 
+
 (defn highlight
   ([text-comp start stop color]
     (when (and (<= 0 start) (<= stop (.. text-comp getDocument getLength)))

--- a/src/clooj/indent.clj
+++ b/src/clooj/indent.clj
@@ -11,7 +11,7 @@
 
 ;(defn t [] (@clooj.core/current-app :doc-text-area))
 
-(def special-tokens 
+(def special-tokens
   ["def" "defn" "defmacro" "let" "for" "loop" "doseq" "if" "when"
    "binding" "case" "definline" "defmacro" "condp" "when-let" "if-let" "fn"
    "proxy" "reify" "when-first" "defmethod" "defmulti" "defn-" "defprotocol"
@@ -22,7 +22,7 @@
 
 (defn first-token [txt]
   (second (re-find #"\((.+?)\s" txt)))
-          
+
 (defn second-token-pos [txt]
   (when-let [x (re-find #".+?\s" (string/trimr (first (.split #"\r?\n" txt))))]
     (.length x)))
@@ -46,26 +46,26 @@
           (compute-indent-size text-comp bracket-pos)
           (+ col
              (condp = bracket
-               \( (left-paren-indent-size (.. text-comp getDocument (getText
-                                                    bracket-pos
-                                                    (- offset bracket-pos))))
+               \( (left-paren-indent-size (.. text-comp getDocument
+                                              (getText bracket-pos
+                                                       (- offset bracket-pos))))
                \\ 0  \[ 1  \{ 1  \" 1
-               1))))))) ;"
+               1)))))))
 
 (defn fix-indent [text-comp line]
   (let [start (.getLineStartOffset text-comp line)
         end (.getLineEndOffset text-comp line)
         document (.getDocument text-comp)
-        line-text (.getText document start (- end start))]
-    (let [old-indent-size (count (re-find #"\A\ +" line-text))]
-      (when-let [new-indent-size (compute-indent-size text-comp start)]       
-        (let [delta (- new-indent-size old-indent-size)]
-          (if (pos? delta)
-            (.insertString document start (apply str (repeat delta " ")) nil)
-            (.remove document start (- delta))))))))
+        line-text (.getText document start (- end start))
+        old-indent-size (count (re-find #"\A\ +" line-text))]
+    (when-let [new-indent-size (compute-indent-size text-comp start)]
+      (let [delta (- new-indent-size old-indent-size)]
+        (if (pos? delta)
+          (.insertString document start (apply str (repeat delta " ")) nil)
+          (.remove document start (- delta)))))))
 
 (defn fix-indent-selected-lines [text-comp]
-  (utils/awt-event 
+  (utils/awt-event
     (dorun (map #(fix-indent text-comp %)
                 (utils/get-selected-lines text-comp)))))
 
@@ -74,7 +74,7 @@
     (apply str "\n" (repeat indent-size " "))))
 
 (defn setup-autoindent [text-comp]
-  (utils/attach-action-keys text-comp                 
+  (utils/attach-action-keys text-comp
     ["cmd1 BACK_SLASH" #(fix-indent-selected-lines text-comp)] ; "cmd1 \"
     ["cmd1 CLOSE_BRACKET" #(utils/indent text-comp)]   ; "cmd1 ]"
     ["cmd1 OPEN_BRACKET" #(utils/unindent text-comp)]) ; "cmd1 ["
@@ -83,9 +83,9 @@
       (proxy [DocumentFilter] []
         (replace [fb offset len text attrs]
           (.replace
-            fb offset len  
+            fb offset len
             (condp = text
-              "\n" (auto-indent-str text-comp offset) 
+              "\n" (auto-indent-str text-comp offset)
               text)
             attrs))
         (remove [fb offset len]

--- a/src/clooj/navigate.clj
+++ b/src/clooj/navigate.clj
@@ -20,7 +20,7 @@
 (defn move-to-line-start [comp]
   (.setCaretPosition comp
     (.getLineStartOffset comp
-      (get-caret-line-number comp)))) 
+      (get-caret-line-number comp))))
 
 (defn move-to-line-end [comp]
   (.setCaretPosition comp
@@ -29,7 +29,7 @@
       (if (= p (.. comp getDocument getLength))
         p
         (dec p)))))
-           
+
 (defn attach-navigation-keys [comp]
   (utils/attach-action-keys comp
     ["cmd1 LEFT" #(move-to-line-start comp)]

--- a/src/clooj/project.clj
+++ b/src/clooj/project.clj
@@ -20,7 +20,7 @@
 
 (defn save-project-set []
   (utils/write-value-to-prefs utils/clooj-prefs "project-set" @project-set))
-    
+
 (defn load-project-set []
   (reset! project-set (into (sorted-set)
                             (utils/read-value-from-prefs utils/clooj-prefs "project-set"))))
@@ -69,7 +69,7 @@
         (.split File/separator))
     (remove empty?)
     (remove #(= % "."))))
-      
+
 (defn file-ancestor?
   "In the file tree, returns true if descendant-file
    is a direct descendant of ancestor-file.
@@ -79,7 +79,7 @@
         descendant (path-components descendant-file)]
     (and (every? true? (map = ancestor descendant))
          (<= (count ancestor) (count descendant)))))
-    
+
 (defn node-children [node]
   (when-not (.isLeaf node)
     (for [i (range (.getChildCount node))]
@@ -121,9 +121,9 @@
 
 (defn load-tree-selection [tree]
   (let [path (utils/read-value-from-prefs utils/clooj-prefs "tree-selection")]
-     (if (nil? path) 
-       false 
-       (do 
+     (if (nil? path)
+       false
+       (do
          (set-tree-selection tree path)
          true))))
 
@@ -183,7 +183,7 @@
 
 (defn file-tree-model [projects]
     (DefaultTreeModel. (root-node projects) false))
-    
+
 (defn update-project-tree [tree]
   (let [model (file-tree-model (vec @project-set))]
     (utils/awt-event
@@ -209,7 +209,7 @@
         selections (.getSelectionPaths tree)]
     (for [selection selections]
       (-> selection .getPath second .getUserObject))))
- 
+
 (defn add-project [app project-path]
   (swap! project-set conj project-path))
 
@@ -226,5 +226,5 @@
 (defn remove-selected-project [app]
   (apply swap! project-set disj (map #(.getAbsolutePath %)
                                      (get-selected-projects app)))
-  (update-project-tree (app :docs-tree)))     
-      
+  (update-project-tree (app :docs-tree)))
+

--- a/src/clooj/repl/external.clj
+++ b/src/clooj/repl/external.clj
@@ -13,7 +13,7 @@
             [clooj.protocols :as protocols]
             [clooj.repl.lein :as lein]
             [clj-inspector.jars :as jars]))
-   
+
 (defn own-clojure-jar
   "Locate the clojure jar being used by clooj (last resort)."
   []
@@ -37,7 +37,7 @@
         jars (filter #(.contains (.getName %) "clojure")
                      (jars/jar-files lib-dir))]
     (first (filter #(jar-contains-class? % "clojure.lang.RT") jars))))
-        
+
 (defn repl-classpath-items
   "Figures out the necessary pieces for a viable classpath
    given a particular project directory."
@@ -49,7 +49,7 @@
                 (own-clojure-jar))
             (str project-path "/lib/*")
             (str project-path "/src")])))
-  
+
 (defn java-binary
   "Returns the fully-qualified path of the java binary."
   []
@@ -64,7 +64,7 @@
       (doto (ProcessBuilder. [(java-binary) "-cp" classpath-str "clojure.main"])
         (.redirectErrorStream true)
         (.directory (io/file (or project-path ".")))))))
-  
+
 (defn launch-repl
   "Launch an outside process with a clojure repl."
   [project-path classpath-items result-writer]
@@ -104,7 +104,7 @@
         (close repl-map))
       (toString [this]
         (str "Repl with classpath" (:classpath repl-map))))))
-    
-  
+
+
 
 

--- a/src/clooj/repl/lein.clj
+++ b/src/clooj/repl/lein.clj
@@ -90,7 +90,7 @@
         port (lein-nrepl-port-number (first (drop-while nil? lines)))]
     {:nrepl (nrepl port out-writer)
      :process process}))
-    
+
 (defn lein-repl-stop
   "Disconnect from the nrepl connection and destroy the lein repl process."
   [{:keys [process nrepl]}]

--- a/src/clooj/repl/main.clj
+++ b/src/clooj/repl/main.clj
@@ -25,6 +25,7 @@
             [clooj.protocols :as protocols]
             [clooj.utils :as utils]))
 
+#_{:clj-kondo/ignore [:use]}
 (use 'clojure.java.javadoc)
 
 (def repl-history {:items (atom nil) :pos (atom 0)})
@@ -234,8 +235,8 @@
                                   txt
                                   caret-pos)))))
         submit #(when-let [txt (.getText ta-in)]
-                  (do (send-to-repl app txt false)
-                      (.setText ta-in "")))
+                  (send-to-repl app txt false)
+                  (.setText ta-in ""))
         at-top #(zero? (.getLineOfOffset ta-in (get-caret-pos)))
         at-bottom #(= (.getLineOfOffset ta-in (get-caret-pos))
                       (.getLineOfOffset ta-in (.. ta-in getText length)))

--- a/src/clooj/repl/main.clj
+++ b/src/clooj/repl/main.clj
@@ -58,10 +58,10 @@
 
 (defn initialize-repl [repl]
   (.evaluate repl
-    (str    
+    (str
       "(do"
       (utils/local-clj-source "clooj/cemerick/pomegranate.clj")
-      (utils/local-clj-source "clooj/repl/remote.clj")    
+      (utils/local-clj-source "clooj/repl/remote.clj")
       "(clooj.repl.remote/repl)"
       ")"
       )))
@@ -94,7 +94,7 @@
          (binding [*source-path* ~short-file
                    *file* ~file]
            (last (map eval ~read-string-code)))))))
-           
+
 (defn print-to-repl
   [app cmd-str silent?]
   (when-let [repl @(app :repl)]
@@ -164,7 +164,7 @@
       (flush [])
       (close [] nil))
     (PrintWriter. true)))
-  
+
 (defn update-repl-in [app]
   (when (pos? (count @(:items repl-history)))
     (.setText (:repl-in-text-area app)
@@ -197,7 +197,7 @@
     (let [classpath-items ;(lein/lein-classpath-items project-path)
           (external/repl-classpath-items project-path)
           repl ;(lein/lein-repl project-path (app :repl-out-writer))
-          (external/repl project-path classpath-items 
+          (external/repl project-path classpath-items
                          (app :repl-out-writer))
           ]
       (initialize-repl repl)
@@ -253,4 +253,4 @@
   (send-to-repl app "(when *e (.printStackTrace *e))" true))
 
 
-  
+

--- a/src/clooj/repl/output.clj
+++ b/src/clooj/repl/output.clj
@@ -36,7 +36,7 @@
                 (insertUpdate [e] (set-scroll-offset e))
                 (removeUpdate [e]))))
     scroll-pane))
-  
+
 ;; manual tests
 
 (defn test-text-area
@@ -59,9 +59,9 @@
       .show)
     text-area
     ))
-                         
+
 (defn write-lines
-  "Write n lines of text (positive integers) in 
+  "Write n lines of text (positive integers) in
    the text-area"
   [text-area n]
   (dotimes [i n]

--- a/src/clooj/repl/remote.clj
+++ b/src/clooj/repl/remote.clj
@@ -4,7 +4,10 @@
 ; arthuredelstein@gmail.com
 
 (ns clooj.repl.remote
-  (:import (java.io StringReader)))
+  (:import (java.io StringReader))
+  (:require
+    [clojure.main :as m]
+    [clojure.pprint :as pp]))
 
 (def silence (atom false))
 
@@ -28,7 +31,7 @@
           [(StringReader. (str "(do " text ")"))]
           (getLineNumber []
                          (+ -1 line (proxy-super getLineNumber))))))
-    
+
 (defn eval-code-at
   "Evaluate some text as code, as though it were located
    in a given file at a particular line number."
@@ -40,7 +43,7 @@
   "Starts a REPL (for nesting in a primitive REPL) that
    prints nicely and suppresses silent evaluations."
   []
-  (clojure.main/repl
+  (m/repl
     :print (fn [x]
              (if @silence
                (do
@@ -48,5 +51,5 @@
                  (println))
                (if (var? x)
                  (println x)
-                 (clojure.pprint/pprint x))))
-    :prompt #(do (clojure.main/repl-prompt) (.flush *out*))))
+                 (pp/pprint x))))
+    :prompt #(do (m/repl-prompt) (.flush *out*))))

--- a/src/clooj/search.clj
+++ b/src/clooj/search.clj
@@ -86,7 +86,7 @@
     (.setVisible case-checkbox true)
     (.setVisible regex-checkbox true)
     (.setVisible close-button true)
-    (if (not (empty? sel-text))
+    (when (seq sel-text)
       (.setText sta sel-text))))
 
 (defn stop-find [app]

--- a/src/clooj/settings.clj
+++ b/src/clooj/settings.clj
@@ -4,10 +4,10 @@
 ; arthuredelstein@gmail.com
 
 (ns clooj.settings
-  (:import 
+  (:import
     (javax.swing JFrame JTabbedPane JLabel
                  JPanel JComboBox Box
-                 JTextField JTextArea 
+                 JTextField JTextArea
                  BoxLayout SpringLayout
                  JButton JCheckBox)
     (java.awt Font GraphicsEnvironment Dimension)
@@ -32,7 +32,7 @@
     (.addDocumentListener
       (.getDocument tf)
       (reify DocumentListener
-        (insertUpdate [_ e] 
+        (insertUpdate [_ e]
                       (change-fun (.getText tf)))
         (removeUpdate [_ e]
                       (change-fun (.getText tf)))
@@ -44,90 +44,81 @@
     (.addItemListener
       (reify ItemListener
         (itemStateChanged [_ e]
-          (change-fun 
-            (= 
-              (.getStateChange e) 
+          (change-fun
+            (=
+              (.getStateChange e)
               ItemEvent/SELECTED)))))))
 
 (defn font-panel []
-  
-  
-  (def graphics-object
-    (memoize (fn [] (.createGraphics
-                      (BufferedImage. 1 1 BufferedImage/TYPE_INT_ARGB)))))
-  
-  (def monospaced?
-    (fn [font]
-      (let [g (graphics-object)
-            m (.getFontMetrics g font)]
-        (apply == (map #(.charWidth m %) [\m \n \. \M \-])))))
-
-  (defn get-all-font-names []
-    (.. GraphicsEnvironment
-        getLocalGraphicsEnvironment
-        getAvailableFontFamilyNames))
-    
-  (defn get-all-fonts-12 []
-    (map #(Font. % Font/PLAIN 12) (get-all-font-names)))
-  
-  (defn get-monospaced-font-names []
-    (map #(.getName %) (filter monospaced? (get-all-fonts-12))))
-  
-  (defn get-necessary-fonts []
-    (if (:show-only-monospaced-fonts @settings)
-      (get-monospaced-font-names)
-      (get-all-font-names)))
-  (let [example-text-area (doto (JTextArea. 
+  (let [graphics-object (delay (.createGraphics
+                                 (BufferedImage. 1 1 BufferedImage/TYPE_INT_ARGB)))
+        monospaced? (fn [font]
+                      (let [g @graphics-object
+                            m (.getFontMetrics g font)]
+                        (apply == (map #(.charWidth m %) [\m \n \. \M \-]))))
+        get-all-font-names (fn []
+                             (.. GraphicsEnvironment
+                                 getLocalGraphicsEnvironment
+                                 getAvailableFontFamilyNames))
+        get-all-fonts-12 (fn []
+                           (map #(Font. % Font/PLAIN 12) (get-all-font-names)))
+        get-monospaced-font-names (fn []
+                                    (map #(.getName %) (filter monospaced? (get-all-fonts-12))))
+        get-necessary-fonts (fn []
+                              (if (:show-only-monospaced-fonts @settings)
+                                (get-monospaced-font-names)
+                                (get-all-font-names)))
+        example-text-area (doto (JTextArea.
                                   "abcdefghijklmnopqrstuvwxyz 0123456789 (){}[]\nABCDEFGHIJKLMNOPQRSTUVWXYZ +-*/= .,;:!? #&$%@|^")
                             (.setFont (Font. (:font-name @settings) Font/PLAIN (:font-size @settings))))
-        example-pane (doto (JPanel. (SpringLayout.))      
+        example-pane (doto (JPanel. (SpringLayout.))
                        (.add example-text-area))
         font-box (combo-box
                    (get-necessary-fonts)
                    (:font-name @settings)
-                   #(do 
+                   #(do
                       (swap! settings assoc :font-name %)
-                      (.setFont 
-                        example-text-area 
+                      (.setFont
+                        example-text-area
                         (Font. % Font/PLAIN (:font-size @settings)))))
         size-box (combo-box
                    (range 5 49)
                    (:font-size @settings)
-                   #(do 
+                   #(do
                       (swap! settings assoc :font-size %)
-                      (.setFont 
-                        example-text-area 
+                      (.setFont
+                        example-text-area
                         (Font. (:font-name @settings) Font/PLAIN %))))
         monospaced-check-box (check-box
                                "Show only monospaced fonts"
                                (:show-only-monospaced-fonts @settings)
                                #(do
-                                  (swap! settings 
+                                  (swap! settings
                                          assoc :show-only-monospaced-fonts %)
-                                  (doto font-box 
-                                    (.setModel 
-                                      (.getModel 
+                                  (doto font-box
+                                    (.setModel
+                                      (.getModel
                                         (JComboBox.
-                                          (into-array 
+                                          (into-array
                                             (get-necessary-fonts)))))
                                     (.setSelectedItem (:font-name @settings)))))
         controls-pane (JPanel.)
         font-pane (JPanel.)]
 
     (utils/constrain-to-parent example-text-area :n 20 :w 15 :s -15 :e -15)
-    
+
     (doto controls-pane
       (.setLayout (BoxLayout. controls-pane BoxLayout/X_AXIS))
-      (.add (Box/createRigidArea (Dimension. 20 0))) 
+      (.add (Box/createRigidArea (Dimension. 20 0)))
       (.add (JLabel. "Font:"))
-      (.add (Box/createRigidArea (Dimension. 25 0)))    
+      (.add (Box/createRigidArea (Dimension. 25 0)))
       (.add font-box)
-      (.add (Box/createRigidArea (Dimension. 25 0)))  
+      (.add (Box/createRigidArea (Dimension. 25 0)))
       (.add (JLabel. "Size:"))
-      (.add (Box/createRigidArea (Dimension. 25 0)))  
+      (.add (Box/createRigidArea (Dimension. 25 0)))
       (.add size-box)
       (.add (Box/createHorizontalGlue)))
-    
+
     (doto font-pane
       (.setLayout (BoxLayout. font-pane BoxLayout/Y_AXIS))
       (.add controls-pane)
@@ -138,19 +129,19 @@
   (let [options-pane (JPanel.)]
     (doto options-pane
       (.setLayout (BoxLayout. options-pane BoxLayout/Y_AXIS))
-      (.add (check-box 
-              "Wrap lines in source editor" 
+      (.add (check-box
+              "Wrap lines in source editor"
               (:line-wrap-doc @settings)
               #(swap! settings assoc :line-wrap-doc %)))
-      (.add (check-box 
-              "Wrap lines in repl output" 
+      (.add (check-box
+              "Wrap lines in repl output"
               (:line-wrap-repl-out @settings)
               #(swap! settings assoc :line-wrap-repl-out %)))
-      (.add (check-box 
-              "Wrap lines in repl input" 
+      (.add (check-box
+              "Wrap lines in repl input"
               (:line-wrap-repl-in @settings)
               #(swap! settings assoc :line-wrap-repl-in %))))))
-  
+
 (defmacro tabs [& elements]
   `(doto (JTabbedPane.)
      ~@(map #(list '.addTab (first %) (second %)) elements)))
@@ -161,7 +152,7 @@
         y (+ (.y bounds) (/ (.height bounds) 2))
         settings-frame (JFrame. "Settings")
         button-pane (JPanel.)]
-    
+
     (doto button-pane
       (.setLayout (BoxLayout. button-pane BoxLayout/X_AXIS))
       (.add (utils/create-button "OK" #(do
@@ -169,7 +160,7 @@
                                         (.dispose settings-frame))))
       (.add (utils/create-button "Apply" #(apply-fn app @settings)))
       (.add (utils/create-button "Cancel" #(.dispose settings-frame))))
-    
+
     (doto settings-frame
       (.setDefaultCloseOperation JFrame/DISPOSE_ON_CLOSE)
       (.setLayout (BoxLayout. (.getContentPane settings-frame) BoxLayout/Y_AXIS))
@@ -180,9 +171,8 @@
               ["Editor options" (editor-options-panel)]))
       (.add (Box/createRigidArea (Dimension. 0 25)))
       (.add button-pane))))
-             
-              
-            
+
+
 (defn show-settings-window [app apply-fn]
   (reset! settings @(:settings app))
   (.show (make-settings-window app apply-fn)))


### PR DESCRIPTION
Add a clj-kondo config and clean up the existing warnings/errors.

Includes a couple small changes, like `run!` instead of `(doall (map ...))`.