### PR TITLE
Fix uberjar generation

### DIFF
--- a/src/clooj/core.clj
+++ b/src/clooj/core.clj
@@ -816,7 +816,6 @@
     (doall (map #(project/add-project app %) (project/load-project-set)))
     (let [frame (app :frame)]
       (utils/persist-window-shape utils/clooj-prefs "main-window" frame)
-      (utils/enable-mac-fullscreen frame)
       (.setVisible frame true)
       (on-window-activation frame #(project/update-project-tree (app :docs-tree))))
     (setup-temp-writer app)

--- a/src/clooj/utils.clj
+++ b/src/clooj/utils.clj
@@ -558,12 +558,3 @@
         java.net.URL.
         slurp)
     (catch Exception _ nil)))
-
-;; OS-specific utils
-
-(defmacro enable-mac-fullscreen
-  "Shows the Mac full-screen double arrow, as introduced in
-   OS X Lion, if possible."
-  [window]
-  (when (is-mac)
-    `(com.apple.eawt.FullScreenUtilities/setWindowCanFullScreen ~window true)))

--- a/src/clooj/utils.clj
+++ b/src/clooj/utils.clj
@@ -111,7 +111,7 @@
 ;; identify OS
 
 (defn get-os []
-  (string/lower-case (.getProperty System "os.name")))
+  (string/lower-case (System/getProperty "os.name")))
 
 (def is-win
   (memoize #(not (neg? (.indexOf (get-os) "win")))))


### PR DESCRIPTION
After these changes, `lein uberjar` succeeds on my machine, and double-clicking `target/clooj-0.5-standalone.jar` opens Clooj.

To make it easy for folks to run Clooj, I think we can initially just create the uberjar locally, make a GitHub release manually, and attach the uberjar to the release.